### PR TITLE
docs: add detailed documentation for  manuals and tasks 📚

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Death Stranding PoC
 
-I want to create a PoC for Death stranding
+I want to expand the PoC for Death stranding, to include:
+
+- A table of orders
+- A table of deliveries
+
+The only data structure with mutable data is the delivery, which is related to an order, and the order is related to a
+client and destination. The delivery data should be persisted to local storage.
 
 ## Tech stack:
 
@@ -24,6 +30,6 @@ I want to create a PoC for Death stranding
 ## Local dev environment
 
 - IDE: Rust Rover by JetBrains
-- Mac book m2 running IOS
+- Mac book running IOS
 - Brew (Package Manager) installed
-- Rust installed: Rustup, cargo rustc are installed v1.89
+- Rust: Rustup, cargo rustc are installed v1.89

--- a/docs/description.md
+++ b/docs/description.md
@@ -1,0 +1,83 @@
+# Stranding: Purpose and How This App Helps You 100% Death Stranding
+
+Last updated: 2025-09-07
+
+## What game is this about?
+
+Death Stranding features a delivery meta‑game at its core: you connect the United Cities of America by completing
+standard and premium orders between facilities. For true completionists, the target is to complete all deliveries — 540
+in total — spanning three regions:
+
+- East Region
+- Central Region
+- West Region
+
+While the in‑game UI shows per‑facility progress, it becomes difficult to answer cross‑cutting questions such as “Which
+Central locations from A–E are still missing?” or “Which orders have I started, stashed, or finished as this user?”
+
+## What does this app do?
+
+This app is a focused progress tracker for Death Stranding deliveries. It models the game’s world and orders so you can
+plan, execute, and verify completion across all 540 deliveries.
+
+Key concepts mirrored from the game:
+
+- Districts/Regions → District and Location models (facilities and hubs; Locations marked as physical where applicable)
+- Orders → Order model (number, name, client, destination, category, weight, max likes)
+- Deliveries (per user) → Delivery model with statuses: In progress, Stashed, Complete, Failed, Lost
+
+With these models, the app provides:
+
+- Two panels:
+    - Admin (/admin): manage master data (Orders, Locations, Districts, Delivery Categories)
+    - App (/app): act on deliveries as a player (take, stash, continue, complete), and track personal progress
+- Rich filtering: filter Orders by district/region, client, destination, category, delivery status, and completion state
+- Relation navigation: jump between Orders, Locations, and Districts to see context and progress per facility
+- Charts and widgets: visualize completion by region or location groups (e.g., Central A–E, F–M, N–W; East), showing
+  Delivered vs Incomplete for the signed‑in user
+- Bulk actions: accept or complete multiple orders when applicable
+
+## How it helps you get 100% completion
+
+The app is designed to make the 540‑delivery goal manageable:
+
+1) Plan by region
+
+- Use the Orders list filters to scope to a region (via District) and then narrow to specific facilities (client or
+  destination).
+- Use the charts (e.g., “Central region A–E”) to quickly see where you are missing completions.
+
+2) Execute efficiently
+
+- From Orders, use per‑row actions to:
+    - Take on order → creates your In progress delivery
+    - Stash delivery → temporarily store cargo at a facility
+    - Continue delivery → resume a stashed run
+    - Make delivery → mark Complete and move cargo to the client location
+- From Deliveries, you can also complete, fail, stash, continue, or mark lost with optional comments.
+
+3) Verify and iterate
+
+- Switch the Orders filter “Completion status” between Complete and Incomplete to confirm which orders you still need
+  for 100%.
+- Click into Locations to see counts of client/destination orders and “Orders completed” badges for an immediate
+  facility‑level overview.
+- Use District and Location relation tabs to traverse remaining work without losing context.
+
+## Typical workflow to 100%
+
+- Pick a region (East, Central, West), then open Orders and filter by that region’s district(s).
+- Toggle Completion status to Incomplete to see what remains.
+- Sort by number or name as you prefer, then start taking on orders.
+- Use the App panel actions to progress each delivery (take → stash/continue as needed → make delivery).
+- Watch the charts update as Delivered counts rise; drill into Locations where counts don’t match expectations.
+- Repeat for each region until all 540 deliveries are Complete for your user.
+
+## Tips
+
+- Use column toggles to reveal district and timestamp columns when needed.
+- When searching orders, try order number first, then partial name matches.
+- Timezone default for actions is Europe/London; adjust dates manually in Deliveries if you’re logging historical runs.
+
+If you’re new to the UI, see docs/manual.md (Admin) and docs/user-manual.md (App) for step‑by‑step navigation details.
+Happy connecting!

--- a/docs/manual-admin.md
+++ b/docs/manual-admin.md
@@ -1,0 +1,183 @@
+# Stranding Admin User Manual
+
+Last updated: 2025-09-07
+
+This manual describes how to use the Stranding admin (Filament 3) to manage Orders, Locations, Districts, and Delivery Categories. It focuses on how to sign in, navigate the main resource views, filter/search data, and move between related records.
+
+Contents
+- Sign in
+- Dashboard overview
+- Global navigation and search
+- Orders
+- Locations
+- Districts
+- Delivery Categories
+- Filtering, sorting, search, and bulk actions
+- Navigating between related records (tabs and links)
+- Tips and conventions (Filament UI)
+
+## Sign in
+- Admin URL: /admin
+  - Example: https://your-domain.test/admin
+- You will be redirected to the Filament login page if not authenticated.
+- Credentials: Use the account provided by your administrator. If your local app is fresh, ensure a user exists and you can authenticate with the default guard. The panel is configured to use Filament’s default authentication middleware.
+
+## Dashboard overview
+- After login you land on the Filament dashboard.
+- Default widgets:
+  - Account widget (top-right dropdown for profile/logout)
+  - Filament Info widget
+- The panel uses an amber primary color theme.
+- Depending on permissions and configuration, you will see the navigation groups in the left sidebar. Common groups:
+  - Orders
+  - Settings → Locations, Districts, Delivery Categories
+
+If custom widgets are added (e.g. charts), they will appear here. The code references an OrdersOverview widget for Orders.
+
+## Global navigation and search
+- Left sidebar: Access the main resources
+  - Orders
+  - Settings
+    - Locations
+    - Districts
+    - Delivery Categories
+- Top search (if enabled in the panel): Use it to find records across resources. Within a specific resource list, use that table’s Search input for column-aware searching.
+
+## Orders
+Path: Admin → Orders
+
+Views available
+- List: Table of orders with sortable, searchable columns.
+- Create: Add a new order (number, name, client, destination, delivery category, max likes, weight).
+- View: Read-only view of a single order with widgets such as OrdersOverview.
+- Edit: Modify an existing order.
+
+Key table columns
+- number (sortable, searchable)
+- name (wraps, searchable)
+- destination.district.name (sortable)
+- client.name (wraps, sortable)
+- destination.name (wraps, sortable)
+- deliveryCategory.name (wraps, sortable, can be toggled on/off in the column picker)
+- max_likes (numeric, sortable, toggleable)
+- weight (numeric, sortable, toggleable)
+- deliveries.status (badge, searchable)
+- created_at / updated_at (toggleable, sortable)
+
+Filters available
+- District (Select by related Districts that have Locations)
+- Client (Select by Location where is_physical = true)
+- Destination (Select by Location where is_physical = true)
+- Delivery category
+- Status checkboxes (multiple may be applied): In progress, Failed, Complete, Stashed, Lost. These filter by related Deliveries’ status.
+
+Create/Edit form fields
+- number (required, unique, numeric)
+- name (required)
+- client (Select from Locations via the client relationship)
+- destination (Select from Locations via the destination relationship)
+- delivery category (Select from Delivery Categories)
+- max_likes (required, numeric)
+- weight (required, numeric, default 0)
+
+Navigating from an Order to related records
+- Client and Destination columns are linked via relationships. Clicking a client/destination name typically opens the related Location’s view.
+- Destination district is shown as destination.district.name. You can open the destination, then navigate to its District from the Location view.
+
+## Locations
+Path: Admin → Settings → Locations
+
+Views available
+- List: Table of locations.
+- Create, View, Edit
+
+Key table columns
+- name (searchable)
+- district.name (sortable)
+- is_physical (boolean icon)
+- client_orders_count (badge)
+- destination_orders_count (badge)
+- deliveries_count (badge)
+- complete_orders_count (badge, green)
+- created_at / updated_at (toggleable, sortable)
+
+Filters available
+- District (Select based on districts that have locations)
+
+Create/Edit form fields
+- name (required, unique)
+- district (Select)
+- is_physical (Toggle)
+- Metadata placeholders: Created at / Last modified at (visible on existing records)
+
+Related resources (tabs on Location view)
+- Deliveries: Shows deliveries associated with this location.
+- Complete Orders: Shows orders completed for this location.
+
+Common navigation patterns from a Location
+- Click the District name to open the District view.
+- Use the relation tabs to see deliveries and completed orders without leaving the Location.
+
+## Districts
+Path: Admin → Settings → Districts
+
+Views available
+- List, Create, View, Edit
+
+Key table columns
+- name (searchable)
+- locations_count (badge)
+- created_at / updated_at (toggleable, sortable)
+
+Related resources (tabs on District view)
+- Locations: Manage or inspect locations belonging to this district.
+
+Navigation
+- From a District’s Locations tab, click a Location to drill down, then use that Location’s tabs (Deliveries, Complete Orders).
+
+## Delivery Categories
+Path: Admin → Settings → Delivery Categories
+
+Views available
+- List, Create, View, Edit
+
+Key table columns
+- name (searchable)
+- orders_count (badge)
+- created_at / updated_at (toggleable, sortable)
+
+Related resources (tabs on Delivery Category view)
+- Orders: Shows orders categorized under this delivery category.
+
+Navigation
+- From a Delivery Category’s Orders tab, click an Order to open its view. From there, you can navigate to the Client/Destination Locations.
+
+## Filtering, sorting, search, and bulk actions
+Applies across resources (patterns provided by Filament tables):
+- Search: Use the search box above the table to search over searchable columns.
+- Sort: Click column headers that indicate sortability. Click again to toggle asc/desc.
+- Filters panel: Open the Filters sidebar/panel to apply select filters or checkboxes. Multiple filters can be combined.
+- Column visibility: Use the column toggler to show/hide optional columns (e.g., deliveryCategory.name, created_at).
+- Pagination: Use the paginator at the bottom to navigate pages. You can adjust per-page size if available.
+- Row actions: Hover a row to reveal actions (View, Edit). Some resources also expose inline actions.
+- Bulk actions: Select multiple rows with the checkboxes and use the Bulk actions dropdown (e.g., Delete on some resources).
+
+## Navigating between related records
+- Linked columns: Where a table column represents a relation (e.g., client.name or destination.name on Orders), clicking it typically takes you to the related record’s view page.
+- Relation tabs: On a record’s View page, related resources appear as tabs. Examples:
+  - Location → Deliveries, Complete Orders
+  - District → Locations
+  - Delivery Category → Orders
+  You can browse, filter, and open related items without leaving the parent record.
+- Breadcrumbs: Use the breadcrumb trail at the top to jump back to the resource list or parent pages.
+
+## Tips and conventions (Filament UI)
+- Keyboard: Use / to focus the search bar (if enabled by your browser/OS), and arrow keys to navigate table focus where supported.
+- Resize and columns: On smaller screens, Filament wraps text and may stack actions into menus.
+- Widgets: Some pages include cards/widgets. For Orders, a widget named OrdersOverview may appear providing summary metrics.
+- Colors and badges: Statuses and counts appear as badges. Delivery status on Orders is a colored badge in the deliveries.status column.
+- Safeguards: Forms validate required and unique fields. If you see validation errors, correct the input and resubmit.
+
+Support
+- If you encounter a permissions or sign-in issue, confirm you’re using the correct admin URL (/admin) and have a valid user/session.
+- For data relationships or missing options (e.g., empty Client/Destination lists), ensure the related Locations and Delivery Categories exist, and that Locations marked as Client/Destination are physical when required by filters.

--- a/docs/manual-user.md
+++ b/docs/manual-user.md
@@ -1,0 +1,190 @@
+# Stranding App Panel User Manual
+
+Last updated: 2025-09-07
+
+This manual describes how to use the Death Stranding PoC app. It covers how to sign in, navigate the top‑navigation
+resources, filter/search data, act on Orders and Deliveries, and move between related records and tabs.
+
+Contents
+
+- Sign in to the App panel
+- Navigation model (Top navigation)
+- Dashboard and widgets
+- Orders
+- Deliveries
+- Filtering, sorting, search, and bulk actions
+- Navigating between related records (links and tabs)
+- Tips and conventions
+
+## Sign in to the App panel
+
+- App URL:
+    - Example: https://pen-y-fan.github.io/death-stranding-poc/
+- If you aren’t authenticated, the app shows the login screen. Use your standard application credentials.
+  Authentication is handled via the app to use social login Auth (e.g. Google or GitHub).
+
+## Navigation (Top navigation)
+
+- The main navigation. You’ll see links as tabs across the top
+  rather than a left sidebar.
+- In this app exposes at least:
+    - Dashboard
+    - Orders
+    - Deliveries
+    - Locations
+- Color palette (for context): primary = Indigo; success = Emerald; warning = Orange; danger = Rose; info = Blue; gray =
+  Gray.
+
+## Dashboard
+
+- After login you land on the App dashboard.
+- Default widgets for the dashboard:
+    - Account panel information (profile and logout via the user menu)
+- Additional App charts you may see on dashboard:
+    - Orders doughnut chart
+    - Complete orders central A to E Chart, 
+    - Complete orders central F to M Chart, 
+    - Complete orders central N to W Chart
+    - Complete orders East Chart
+
+## Orders
+
+Path: /orders
+
+Views available
+
+- List: Table of orders with sortable/searchable columns, filters, and per‑row actions.
+  - Act on orders as a player (take, store, continue, complete), and track personal progress.
+    orders (taking, storeing, completing). The order is immutable, when a play acts on an order a delivery is created.
+- View: Read‑only details for a single order, plus widgets (OrdersOverview) and related data.
+- Edit: No option to edit orders.
+- Create: No option to edit orders.
+
+Key table columns (App panel)
+
+- number (int) (sortable, searchable)
+- name (wraps, searchable)
+- max_likes (numeric, sortable, toggleable)
+- weight (numeric, sortable, toggleable)
+- client.name (wraps, sortable, toggleable)
+- destination.name (wraps, sortable, toggleable)
+- destination.district.name (sortable, hidden by default via column toggler)
+- deliveryCategory.name (sortable, toggleable)
+- userDeliveries.status (badge labeled “Deliveries”, searchable)
+
+Filters available (above content)
+
+- District: Filter by related districts that have locations.
+- Client: Filter by client location (physical locations only).
+- Destination: Filter by destination location (physical locations only).
+- Delivery category: Filter by category.
+- Delivery status: Select one status (In progress, Complete, Stored, Failed, Lost) to filter orders by the current
+  user’s deliveries.
+- Completion status: Choose Complete or Incomplete to include orders the current user has completed vs not yet
+  completed.
+
+Per‑row actions (contextual to the signed‑in user)
+
+- Take on order: Creates an IN_PROGRESS delivery for the current user if you don’t already have an active/Stored
+  delivery for that order.
+- Store delivery: For an IN_PROGRESS delivery you hold, store it to a chosen location with optional comment.
+- Continue delivery: For a Stored delivery you hold, resume it (status back to IN_PROGRESS).
+- Make delivery: Complete a delivery you hold (sets ended_at and marks COMPLETE, moving cargo to the client’s location).
+
+Form fields (will be supplied to the app e.g JSON or Rust built in collection)
+
+- number (int, required, unique, numeric) this is also a sequence.
+- name (string, required)
+- client (Location)
+- destination (Location)
+- delivery category (deliveryCategory - possibly an Enum or similar structured data)
+- max_likes (float, required, numeric)
+- weight (float, required, numeric, default 0)
+
+Navigation from Orders to related records
+
+- client.name and destination.name are clickable relation columns. Clicking either typically opens the related Location
+  view (in the appropriate panel/resource).
+- destination.district.name is visible (often via toggled column). To inspect the district, open the destination
+  Location and then click its District link.
+
+## Deliveries
+
+Path: /deliveries
+
+Views available
+
+- List: Table of your deliveries (by default, query can be limited to user scope when implemented) with filters and
+  actions.
+- Create: Create a delivery (select order, location, status, optional times and comment).
+- Edit: Update an existing delivery.
+- Delete: Delete a delivery (e.g. if taken in error).
+
+Key table columns
+
+- order.number and order.name (click either to open the associated Order view)
+- location.name
+- started_at, ended_at (dates - in the user timezone)
+- status (badge; values come from DeliveryStatus enum)
+- comment (truncated, wrap)
+- created_at / updated_at (toggleable, sortable)
+
+Filters
+
+- Status: Filter deliveries by status (e.g., In progress, Complete, Stored, Failed, Lost).
+
+Row actions (buttons)
+
+- Edit: opens edit form.
+- Complete: Marks delivery COMPLETE, sets ended_at, and moves cargo to the order’s client location.
+- Fail: Marks delivery FAILED and moves cargo to the order’s destination; optional comment recorded.
+- Lost: Marks delivery LOST; optional comment recorded.
+- Store: Switches to Stored at a chosen location (requires selecting a location and optional comment).
+- Continue: Displayed for stored back to IN_PROGRESS (optionally adding a comment). Some actions are only visible for
+  compatible current statuses.
+
+Create/Edit delivery form fields
+
+- Order (searchable select: type order number or name)
+- Location (searchable select - the current location of the order - can be a Location or carried)
+- started_at (defaults to Europe/London now - should be set to the users current date time)
+- ended_at (optional)
+- status (radio from DeliveryStatus values)
+- comment (optional)
+
+## Filtering, sorting, search, and bulk actions
+
+- Search: Use the search field above each table to search searchable columns.
+- Sort: Click on sortable column headers; click again to toggle ascending/descending.
+- Filters: Open the filters area above the content to combine filters (e.g., District + Delivery status).
+- Column visibility: Use the column toggler to reveal or hide optional columns such as district or timestamps.
+- Pagination: Use the paginator at the bottom to switch pages; adjust per‑page size if available.
+- Bulk actions:
+    - Orders: Accept and Complete (bulk) actions are available using checkboxes to select multiple rows.
+      - Bulk Accept: Creates a delivery of each selected orders as IN_PROGRESS (only if there are no existing deliveries in progress).
+      - Bulk Complete: Marks selected orders.delivery as COMPLETE (even if no delivery exists, create a completed one, if one exists amend it to complete).
+    - Deliveries: Bulk Delete is available.
+
+## Navigating between related records (links and tabs)
+
+- Linked columns: Clicking a relation value (e.g., client.name, destination.name, order.number on Deliveries) navigates
+  to that record’s detail view.
+- From Delivery → Order: order.number and order.name in Deliveries link to the Order view page.
+- From Order → Locations/Districts: open the destination or client Location by clicking its name; from the Location you
+  can proceed to its District where applicable.
+- Breadcrumbs: Use the breadcrumb trail at the top to return to resource lists or parent pages.
+
+## Tips and conventions
+
+- Top navigation: The App panel uses tabs across the top instead of a sidebar, improving focus on operational tasks.
+- Widgets: App widgets (charts/doughnuts) surface progress by district or region. Data is scoped to the signed‑in user
+  for completion charts.
+- Status badges: DeliveryStatus values render as colored badges across Orders and Deliveries.
+- Validation: Forms validate required and unique fields; fix validation errors and resubmit.
+- Timezone: Some actions set times with Europe/London timezone by default.
+
+Support
+
+- If you cannot sign in, verify you’re using the correct URL (/app) and that your account has access to the App panel.
+- If select lists are empty (e.g., choosing a client/destination), ensure Locations and Delivery Categories exist and
+  that relevant Locations are marked as physical when required.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,105 @@
+# Project Tasks Checklist
+
+Last generated: 2025-09-08 13:23
+
+Below is an ordered, actionable checklist derived from docs/description.md, docs/manual-user.md, and the current codebase. Each item starts with a checkbox [ ] to track completion. Tasks cover architecture, build/deploy, data modeling, WASM boundary, business logic, UI shell, and testing. Where relevant, required input data is identified (e.g., JSON files for Orders, Locations, etc.).
+
+1. [ ] Architecture and build pipeline
+   1. [ ] Switch CI/CD (GitHub Pages workflow) to wasm-pack to generate ./pkg JS glue expected by index.html. (Build ./pkg and deploy index.html + pkg/) 
+   2. [ ] Ensure toolchain steps in CI: install wasm32-unknown-unknown target and install wasm-pack. 
+   3. [ ] Adjust workflow to publish docs/ with index.html and pkg/ using actions/upload-pages-artifact + actions/deploy-pages. 
+   4. [ ] Document local dev quickstart in README: wasm-pack build --target web --release; basic-http-server .
+
+2. [ ] Crate configuration and dependencies
+   1. [ ] Confirm [lib] crate-type includes ["cdylib", "rlib"]. 
+   2. [ ] Ensure web-sys features include Window and Storage (already present); add any new APIs explicitly when used. 
+   3. [ ] Pin compatible versions for wasm-bindgen, web-sys, serde/serde_json; document upgrade path.
+
+3. [ ] Data model definition (align with manual-user.md and description.md)
+   1. [ ] Define core structs with serde support:
+       - [ ] District { id, name, region (East/Central/West) }
+       - [ ] Location { id, name, district_id, is_physical }
+       - [ ] DeliveryCategory { id, name }
+       - [ ] Order { number (unique, int), name, client_id (Location), destination_id (Location), delivery_category_id, max_likes (f32), weight (f32) }
+       - [ ] DeliveryStatus enum { IN_PROGRESS, STORED, COMPLETE, FAILED, LOST }
+       - [ ] Delivery { id, order_number, status: DeliveryStatus, location_id, started_at, ended_at, comment, user_id }
+   2. [ ] Provide JSON schemas/examples for seed data (see Required data section below). 
+   3. [ ] Validate constraints (e.g., Order.number unique; required fields) at import time.
+
+4. [ ] Data loading and persistence (WASM boundary)
+   1. [ ] Implement JSON import functions exposed via wasm-bindgen to load master data into localStorage: districts.json, locations.json, delivery_categories.json, orders.json. 
+   2. [ ] Implement getters to read current state from localStorage with robust error handling. 
+   3. [ ] Implement JSON export/backup for deliveries per user. 
+   4. [ ] Add versioning key in storage to handle migrations (e.g., schema_version).
+
+5. [ ] Business logic for deliveries (user actions)
+   1. [ ] take_order(number): create IN_PROGRESS delivery if the user has no active or stored delivery for that order. 
+   2. [ ] store_delivery(number, location_id, comment?): set status to STORED with location. 
+   3. [ ] continue_delivery(number, comment?): move STORED → IN_PROGRESS. 
+   4. [ ] make_delivery(number): set COMPLETE, ended_at=now, move cargo to client location. 
+   5. [ ] fail_delivery(number, comment?): set FAILED and move cargo to destination. 
+   6. [ ] lose_delivery(number, comment?): set LOST. 
+   7. [ ] Bulk actions: 
+       - [ ] bulk_accept(order_numbers[]): create IN_PROGRESS deliveries where none in-progress exist. 
+       - [ ] bulk_complete(order_numbers[]): if no delivery exists, create COMPLETE; if exists, set COMPLETE. 
+   8. [ ] Enforce status transition rules and edge cases; record timestamps in Europe/London (or user tz when available).
+
+6. [ ] Filtering, sorting, and search (data services)
+   1. [ ] Implement pure-Rust filter functions for Orders by: District, Client, Destination, DeliveryCategory, DeliveryStatus (for current user), Completion status. 
+   2. [ ] Implement sort/search helpers (by number, name, weight, max_likes) to keep JS layer thin. 
+   3. [ ] Provide WASM-exposed functions to query paginated/filtered lists suitable for a simple UI.
+
+7. [ ] UI shell integration (index.html minimal enhancements)
+   1. [ ] Replace placeholder table with functions that call new WASM APIs for lists and actions. 
+   2. [ ] Add simple top navigation tabs: Dashboard, Orders, Deliveries, Locations (static HTML/JS). 
+   3. [ ] Wire up per-row actions: Take, Store (with prompt for location/comment), Continue, Make delivery, Fail, Lost. 
+   4. [ ] Add basic filters UI to Orders: dropdowns for District/Client/Destination/Category, radio for Delivery Status and Completion.
+
+8. [ ] Charts and dashboard (optional PoC scope)
+   1. [ ] Provide WASM-exposed summary endpoints for counts by region and location groups (Central A–E/F–M/N–W; East). 
+   2. [ ] Render simple doughnut/progress charts in JS (or text summaries as PoC).
+
+9. [ ] Navigation between related records
+   1. [ ] Provide WASM data lookups for relation expansion (e.g., get_location(id), get_district(id)). 
+   2. [ ] Update UI to make client/destination clickable to open related info panel.
+
+10. [ ] Validation and error handling
+    1. [ ] Validate inputs on all WASM-exposed functions; return Result-like error strings across the boundary. 
+    2. [ ] Handle localStorage errors (quota, unavailable) gracefully.
+
+11. [ ] Testing (native and wasm)
+    1. [ ] Add native unit tests for pure logic (status transitions, filtering, sorting, validation). 
+    2. [ ] Add wasm-bindgen-test for WASM boundary where feasible (optional headless). 
+    3. [ ] Ensure existing native build remains working under cfg(target_arch) gating. 
+    4. [ ] Provide test fixtures (JSON) for Orders/Locations/etc. 
+    5. [ ] Add tests for bulk actions edge cases (e.g., duplicate accept, complete without existing delivery). 
+
+12. [ ] Deployment (GitHub Pages)
+    1. [ ] Update .github/workflows/deploy.yml to wasm-pack build and publish docs/ with pkg/ and index.html. 
+    2. [ ] Add a manual deployment note in README for GitHub Pages settings. 
+    3. [ ] Post-deploy smoke checklist: load page, verify pkg/death_stranding_poc.js exists, actions function.
+
+13. [ ] Required data (you can supply these as JSON files)
+    1. [ ] districts.json: list of Districts with region names (East/Central/West). 
+    2. [ ] locations.json: Facilities with district_id and is_physical flag. 
+    3. [ ] delivery_categories.json: Category taxonomy. 
+    4. [ ] orders.json: All 540 Orders with required fields (number, name, client_id, destination_id, delivery_category_id, max_likes, weight). 
+    5. [ ] users.json (optional): If multi-user scoping is needed; otherwise infer a single current user. 
+    6. [ ] deliveries.json (optional initial state): Seed for demo/testing.
+
+14. [ ] Time and timezone handling
+    1. [ ] Decide and implement Europe/London default timestamping on actions; allow override for tests. 
+    2. [ ] Store timestamps in ISO 8601 UTC with separate display-timezone transformation in UI.
+
+15. [ ] Documentation updates
+    1. [ ] Update README with build/run/test instructions (wasm-pack, local server). 
+    2. [ ] Add brief API docs for exposed WASM functions. 
+    3. [ ] Link to docs/manual-user.md and docs/description.md from README. 
+
+16. [ ] Performance and size (PoC-appropriate)
+    1. [ ] Keep web-sys features minimal; audit features if adding new APIs. 
+    2. [ ] Release builds with wasm-opt (if available via wasm-pack) for smaller payloads. 
+
+17. [ ] Accessibility and UX basics (PoC scope)
+    1. [ ] Ensure buttons have accessible labels; keyboard navigation for list actions. 
+    2. [ ] Provide minimal ARIA roles for tables and status summaries.


### PR DESCRIPTION
- Added comprehensive admin and user guides under `docs/`, detailing the usage of all functionalities related to Orders, Locations, Districts, and Deliveries.
- Included a project tasks checklist to outline key development steps and user flow explanations for `Death Stranding` PoC app.