### PR TITLE
refactor: split build and deploy jobs 🛠️

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,16 +17,12 @@ permissions:
   id-token: write
 
 jobs:
-  build_and_deploy:
+  # Build job
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -39,7 +35,7 @@ jobs:
       - name: Run JS Tests
         run: npm test
 
-      - name: Prepare GitHub Pages deployment
+      - name: Prepare static files
         run: |
           mkdir -p docs_deploy
           cp -R js docs_deploy/
@@ -47,11 +43,19 @@ jobs:
           cp -R data docs_deploy/
           cp index.html docs_deploy/
 
-      - name: Upload artifact
+      - name: Upload static files as artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs_deploy
+          path: docs_deploy/
 
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -151,6 +151,7 @@ JSON files for Orders, Locations, etc.).
     3. [x] Implement a static version number display in the top-right corner of the app.
     4. [x] Create a Pull Request template with a "Version number bumped?" checklist.
     5. [x] Fix schema validation in `.github/workflows/deploy.yml` (move `environment` to job level).
+    6. [x] Fix GitHub Pages 404 error by splitting `build` and `deploy` jobs in `.github/workflows/deploy.yml` and correctly using `actions/upload-pages-artifact` and `actions/deploy-pages`.
 
 23. [x] Administrative and Advanced Features (Alignment with Manuals)
     1. [x] Implement "Settings" navigation for managing Locations, Districts, and Delivery Categories.
@@ -205,4 +206,4 @@ JSON files for Orders, Locations, etc.).
         - [x] Clean up Google API/OAuth2 related unresolved references if not used.
         - [x] Fix hover state for settings navigation buttons (prevent text color matching background color).
 
-Last generated: 2026-03-24 23:32
+Last generated: 2026-03-25 13:52

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     </div>
 </nav>
 
-<div id="app-version">v0.1.1</div>
+<div id="app-version">v0.1.2</div>
 
 <section id="panel-dashboard" hidden>
     <h1>Dashboard</h1>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "death-stranding-poc",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Death Stranding PoC",
   "type": "module",
   "scripts": {


### PR DESCRIPTION

## Summary

Separated the `build` and `deploy` jobs in the deployment workflow for better modularity. Fixed GitHub Pages 404 error by correctly using `actions/upload-pages-artifact` and `actions/deploy-pages`.

## Checklist

- [x] Has the version number been bumped?
- [x] Have the tests been run?
- [x] Does it work on mobile/tablet?
